### PR TITLE
NBNV-966 - Made the taxon name always visible for records in the picker

### DIFF
--- a/src/scripts/templates/TaxonObservations.tpl
+++ b/src/scripts/templates/TaxonObservations.tpl
@@ -1,12 +1,10 @@
 <table cellpadding="0" cellspacing="0" border="0" class="display" id="example">
   <thead>
     <tr>
+      <th>Taxon Name</th>
       <th>Organisation</th>
       <th>Location</th>
       <th>Site Name</th>
-      <% if(!isFilteredByTaxon) { %>
-        <th>Taxon Name</th>
-      <%}%>
       <th>Start Date</th>
       <th>End Date</th>
       <th>Recorder</th>
@@ -15,12 +13,10 @@
   <tbody>
     <% _.each(observations, function(observation){ %>
       <tr>
+        <td><%=observation.pTaxonName%> <%=observation.pTaxonAuthority%></td>        
         <td><a href="<%=observation.dataset.href%>" target="_blank"><%=observation.dataset.organisationName%></a></td>
         <td><%=observation.location%></td>
         <td><%=observation.siteName%></td>
-        <% if(!isFilteredByTaxon) { %>
-          <td><%=observation.pTaxonName%> <%=observation.pTaxonAuthority%></td>
-        <%}%>
         <td><%=observation.startDate%></td>
         <td><%=observation.endDate%></td>
         <td><%=observation.recorder%></td>


### PR DESCRIPTION
NBNV-966 - Made the taxon name always visible for records in the picker, might need re-sizing but works fine (removed optional taxon name part of the template), left in the logic that made it appear before as it might be used at some other points.
