### PR TITLE
Re-sized date columns to prevent them from splitting the dates

### DIFF
--- a/src/scripts/views/TaxonObservationsView.coffee
+++ b/src/scripts/views/TaxonObservationsView.coffee
@@ -17,7 +17,13 @@ define [
       "bLengthChange": false
       "oLanguage":
         "sSearch": "Search within these results:"
-    
+      "aoColumnDefs": [
+        {
+          "sWidth":"11%"
+          "aTargets":[4,5]
+        }
+      ]
+
     if (@collection.apiFailed)
       $(".polygonErrorMessage").text  @collection.apiFailureMessage
     else


### PR DESCRIPTION
Just a simple addition, prevents the datatables plugin from splitting the date columns as it just looks terrible in my opinion
