### PR TITLE
Better scale dependency

### DIFF
--- a/src/scripts/collections/Layers.coffee
+++ b/src/scripts/collections/Layers.coffee
@@ -52,15 +52,15 @@ define [
   ###
   setResolution: (resolution) ->
     @state.set "autoResolution", 
-      if 5 > resolution then '100m'
-      else if 40 > resolution then '1km'
-      else if 175 > resolution then '2km'
+      if 20 > resolution then '100m'
+      else if 155 > resolution then '1km'
+      else if 310 > resolution then '2km'
       else '10km'
 
     @state.set "maxResolution",
       if 40 > resolution then '100m'
       else if 350 > resolution then '1km'
-      else if 700 > resolution then '2km'
+      else if 1300 > resolution then '2km'
       else if 6000 > resolution then '10km'
       else 'Polygon'
 

--- a/test/collections/Layers.spec.coffee
+++ b/test/collections/Layers.spec.coffee
@@ -1,5 +1,5 @@
 define [
-	"cs!collections/Layers"
+  "cs!collections/Layers"
   "cs!models/SingleSpeciesLayer"
   "cs!models/TaxonObservationTypes"
 ], (Layers, SingleSpeciesLayer, TaxonObservationTypes)-> 
@@ -13,7 +13,7 @@ define [
       testLayer = new SingleSpeciesLayer;
       layers.add testLayer
 
-      layers.setResolution 200
+      layers.setResolution 5000
 
       expect(testLayer.get 'autoResolution').toBe "10km"
 
@@ -36,7 +36,7 @@ define [
       expect(layers.at(0)).toBe layer2
     
     it "syncs the max/auto resolution state with new layers", ->
-      layers.setResolution 50
+      layers.setResolution 305
       testLayer = new SingleSpeciesLayer
 
       layers.add testLayer
@@ -60,8 +60,8 @@ define [
       expect(layers.at(1).get 'isPresence').toBe false
 
     describe "auto resolution", ->
-      it "goes to 10km at 200 resolution", ->
-        layers.setResolution 200
+      it "goes to 10km at 400 resolution", ->
+        layers.setResolution 400
         expect(layers.state.get 'autoResolution').toBe '10km'
 
       it "goes to 2km at 160 resolution", ->


### PR DESCRIPTION
I have changed the scale dependency levels for automatic zooming and maximum zoom levels.

Basically you get to the higher resolution data quicker, I think this will be acceptable once the new caching code has gone live.

This pull will reduce maps like this:
![image](https://cloud.githubusercontent.com/assets/1215415/2927259/24ac9140-d769-11e3-8d5c-9a7edf14bee5.png)

and make them:

![image](https://cloud.githubusercontent.com/assets/1215415/2927261/367b3fde-d769-11e3-8e4a-16f39be0a07b.png)
